### PR TITLE
Add 'iphoenix' as alias for iphoenix persona.

### DIFF
--- a/personalitiesrc.py
+++ b/personalitiesrc.py
@@ -31,7 +31,7 @@ personality_regexes = {
     'oldmud0': r'oldmud0',
     'little': r'little',
     'jacobkuschel': r'jacob_kuschel',
-    'iphoenix': r'_iphoenix_',
+    'iphoenix': r'_iphoenix_|iphoenix',
     'michael23b': r'michaelb|michael2_3b',
     'pieman': r'pieman',
     'battlesquid': r'squid|battlesquid',


### PR DESCRIPTION
I use this username on cemetech's IRC and discord, as '_iPhoenix_' is too long.